### PR TITLE
Fixed TypeError: Cannot read property 'url' of undefined

### DIFF
--- a/gatsby-theme-document/src/components/LeftSidebar/Navigation.js
+++ b/gatsby-theme-document/src/components/LeftSidebar/Navigation.js
@@ -17,6 +17,11 @@ const calculateTreeData = (edges, sidebarConfig) => {
         }) => slug !== '/'
       )
     : edges;
+
+  if (originalData.length === 0) {
+    return { items: [] };
+  }
+
   const tree = originalData.reduce(
     (
       accu,


### PR DESCRIPTION
Setup
- ignoreIndex: true

Issue
- only index page existed and items was an array with undefined instead of being empty

Had an error when I set ignoreIndex to true and didn't have any other pages made. Figured it might be common when starting out with a document style site to not have any other pages made for a little while. So here's a fix if you're interested.

PS - I really like the theme!