### PR TITLE
Make left sidebar recursive to allow multiple levels of folders

### DIFF
--- a/gatsby-theme-document/src/components/LeftSidebar/NavItem.js
+++ b/gatsby-theme-document/src/components/LeftSidebar/NavItem.js
@@ -4,32 +4,33 @@ import React, { useContext } from 'react';
 import { GlobalDispatchContext, GlobalStateContext } from '../../context/GlobalContextProvider';
 import ButtonCollapse from '../ButtonCollapse';
 
-const NavItem = ({ item }) => {
+const NavItem = ({ items, url = '', title = '' }) => {
   const state = useContext(GlobalStateContext);
   const dispatch = useContext(GlobalDispatchContext);
-  const isCollapsed = state.collapsed[item.url];
-  const hasChildren = item.items && item.items.length > 0;
+  const isCollapsed = state.collapsed[url];
+  const hasChildren = items && items.length > 0;
   return (
     <StyledNavItem>
-      <NavItemLink to={item.url} activeClassName="is-active">
-        {item.title}
+      {title !== '' && (
+      <NavItemLink to={url} activeClassName="is-active">
+        {title}
       </NavItemLink>
-      {hasChildren && (
+      )}
+      {hasChildren && title !== '' && (
         <ButtonCollapse
           onClick={() => {
-            dispatch({ type: 'TOGGLE_NAV_COLLAPSED', url: item.url });
+            dispatch({ type: 'TOGGLE_NAV_COLLAPSED', url: url });
           }}
           isCollapsed={isCollapsed}
         />
       )}
       {hasChildren && !isCollapsed && (
         <NavItemChild>
-          {item.items.map(child => (
-            <StyledNavItem key={child.url}>
-              <NavItemLink to={child.url} activeClassName="is-active">
-                {child.title}
-              </NavItemLink>
-            </StyledNavItem>
+          {items.map(item => (
+            <NavItem
+              key={item.url}
+              {...item}
+              />
           ))}
         </NavItemChild>
       )}

--- a/gatsby-theme-document/src/components/LeftSidebar/Navigation.js
+++ b/gatsby-theme-document/src/components/LeftSidebar/Navigation.js
@@ -127,9 +127,7 @@ const Navigation = () => {
   });
   return (
     <NavList>
-      {treeData.items.map(item => (
-        <NavItem key={item.url} item={item} />
-      ))}
+      <NavItem {...treeData} />
     </NavList>
   );
 };


### PR DESCRIPTION
I noticed that the `sidebar` component in the [gatsby-gitbook-starter](https://github.com/hasura/gatsby-gitbook-starter) project that was used as a starting point for the `LeftSidebar` component has been updated to work recursively, thereby adding support for multiple levels of folders. So I thought I would try and add the same functionality to this project since it was requested by [@taufn](https://github.com/taufn) in [issue 14](https://github.com/codebushi/gatsby-theme-document/issues/14).

Here's a screenshot of the new sidebar in action:
<img width="1030" alt="image" src="https://user-images.githubusercontent.com/9327871/105447818-d14f9400-5c29-11eb-9f8b-cf4caf26b0d4.png">

Hope this helps!